### PR TITLE
Modifica funzione  wppa_breadcrumb()

### DIFF
--- a/design-italia/functions.php
+++ b/design-italia/functions.php
@@ -404,7 +404,7 @@ function wppa_breadcrumb() {
     echo '</a></li>';
     if (is_category() || is_single()) {
       echo '<li class="breadcrumb-item">';
-      the_category(' </li><li class="breadcrumb-item"> ');
+      echo implode(' </li><li class="breadcrumb-item"> ',array_reverse(explode(',',get_the_category_list(','))));
       if (is_single()) {
         echo '</li><li class="breadcrumb-item">';
         the_title();


### PR DESCRIPTION
Consente di visualizzare le categorie (prima parent e poi child) nel corretto ordine nella breadcrumb del single post